### PR TITLE
feat: output workflow URL as GitHub Actions output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,23 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: NPM install
         uses: bahmutov/npm-install@v1
 
       - name: Run tests 🧪
         run: npm test
+
+      # check how the code can output something when running
+      # using GitHub Actions
+      # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions
+      - name: Set output test1 variable
+        run: echo ::set-output name=test1::hello
+        id: var1
+
+      - name: Use the set output variables
+        run: echo Test1 variable is ${{ steps.var1.outputs.test1 }}
 
       - name: Semantic Release 🚀
         uses: cycjimmy/semantic-release-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,13 @@ jobs:
       - name: Use the set output variables
         run: echo Test1 variable is ${{ steps.var1.outputs.test1 }}
 
+      - name: Set output test2 variable
+        run: node ./test2/output-variable
+        id: var2
+
+      - name: Use the set output variables test2
+        run: echo Test2 variable is ${{ steps.var2.outputs.test2 }}
+
       - name: Semantic Release 🚀
         uses: cycjimmy/semantic-release-action@v2
         with:

--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ Run this utility with the environment variable `DEBUG=trigger-circleci-pipeline`
 
 You can use the `--dry` parameter to avoid actually triggering the pipeline, and just print the parsed parameters.
 
+## GitHub Actions
+
+When running this utility on GitHub Actions, if there is a single CircleCI workflow URL, then this code sets the output variable `CircleCIWorkflowUrl`. You can use it in the later steps:
+
+```yml
+- name: Trigger the CircleCI run
+  run: npx trigger-circleci-pipeline ...
+  id: trigger
+- name: Use the workflow URL
+  run: echo "URL is ${{ steps.trigger.output.CircleCIWorkflowUrl }}"
+```
+
 ## Demo
 
 Run the [demo.sh](./demo.sh) to trigger a workflow build in the project [bahmutov/todomvc-tests-circleci](https://github.com/bahmutov/todomvc-tests-circleci) with results at [CircleCI](https://app.circleci.com/pipelines/github/bahmutov/todomvc-tests-circleci). Using [as-a](https://github.com/bahmutov/as-a) is recommended.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "arg": "^5.0.1",
-        "debug": "^4.3.2",
+        "debug": "^4.3.4",
         "got": "^11.8.2"
       },
       "bin": {
@@ -780,29 +780,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/ava/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ava/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
     },
     "node_modules/ava/node_modules/escape-string-regexp": {
       "version": "5.0.0",
@@ -1634,9 +1611,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -8493,23 +8470,6 @@
             "escape-string-regexp": "5.0.0"
           }
         },
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-              "dev": true
-            }
-          }
-        },
         "escape-string-regexp": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -9131,9 +9091,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/bahmutov/trigger-circleci-pipeline#readme",
   "dependencies": {
     "arg": "^5.0.1",
-    "debug": "^4.3.2",
+    "debug": "^4.3.4",
     "got": "^11.8.2"
   },
   "devDependencies": {

--- a/src/print-workflows.js
+++ b/src/print-workflows.js
@@ -62,7 +62,8 @@ async function printWorkflows(pipelineId, circleCiApiToken) {
 
     console.log('%d workflow(s) for pipeline %s', items.length, pipelineId)
     items.forEach((w) => {
-      console.log('%s %s %s', w.name, w.status, getWebAppUrl(w))
+      const url = getWebAppUrl(w)
+      console.log('%s %s %s', w.name, w.status, url)
     })
   } catch (err) {
     if (err.response.statusCode === 400) {

--- a/src/print-workflows.js
+++ b/src/print-workflows.js
@@ -1,6 +1,10 @@
 // @ts-check
 const got = require('got')
 const debug = require('debug')('trigger-circleci-pipeline')
+const { writeFileSync } = require('fs')
+
+const isGitHubActions = Boolean(process.env.CI && process.env.GITHUB_ACTION)
+debug('running on GitHub Actions?', isGitHubActions)
 
 function getUrl(pipelineId) {
   const pipelineUrl = `https://circleci.com/api/v2/pipeline/${pipelineId}/workflow`
@@ -64,6 +68,18 @@ async function printWorkflows(pipelineId, circleCiApiToken) {
     items.forEach((w) => {
       const url = getWebAppUrl(w)
       console.log('%s %s %s', w.name, w.status, url)
+
+      if (isGitHubActions && items.length === 1) {
+        // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions
+        debug('setting the single workflow as GitHub Actions step output')
+        console.log(`::set-output name=CircleCIWorkflowUrl::${url}`)
+        if (process.env.GITHUB_STEP_SUMMARY) {
+          const summary = `CircleCI workflow URL: ${url}\n`
+          writeFileSync(process.env.GITHUB_STEP_SUMMARY, summary, {
+            flag: 'a+',
+          })
+        }
+      }
     })
   } catch (err) {
     if (err.response.statusCode === 400) {

--- a/test2/output-variable.js
+++ b/test2/output-variable.js
@@ -1,0 +1,4 @@
+// try to write GitHub Actions variable
+if (process.env.CI && process.env.GITHUB_ACTION) {
+  console.log('::set-output name=test2::ciao')
+}


### PR DESCRIPTION
- closes #5

## GitHub Actions

When running this utility on GitHub Actions, if there is a single CircleCI workflow URL, then this code sets the output variable `CircleCIWorkflowUrl`. You can use it in the later steps:

```yml
- name: Trigger the CircleCI run
  run: npx trigger-circleci-pipeline ...
  id: trigger
- name: Use the workflow URL
  run: echo "URL is ${{ steps.trigger.output.CircleCIWorkflowUrl }}"
```